### PR TITLE
release the library name, so it will load libreadline.dylib on Mac

### DIFF
--- a/lib/resty/repl/readline.lua
+++ b/lib/resty/repl/readline.lua
@@ -63,7 +63,7 @@ ffi.cdef[[
   int rl_point;
 ]]
 
-local clib = ffi.load 'libreadline'
+local clib = pcall(ffi.load, 'libreadline') or ffi.load 'libreadline.so.6'
 
 local function history_file_is_writable()
   local history_fn = readline_utils.history_fn()

--- a/lib/resty/repl/readline.lua
+++ b/lib/resty/repl/readline.lua
@@ -63,7 +63,7 @@ ffi.cdef[[
   int rl_point;
 ]]
 
-local clib = ffi.load 'libreadline.so.6'
+local clib = ffi.load 'libreadline'
 
 local function history_file_is_writable()
   local history_fn = readline_utils.history_fn()


### PR DESCRIPTION
Now `lua-resty-repl` can be used on Mac! 😄 
Thanks for your great job!
```
☁  lua-resty-repl [readline-name] ⚡ uname -s
Darwin
☁  lua-resty-repl [readline-name] ⚡ resty-repl
[1] lua(main)> p
package   pairs     parg      pcall     print     progargs
```